### PR TITLE
Fix installation from PyPI sources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-include *.rst
+include pypi-readme.rst
+include ez_setup.py
 include *.txt
 recursive-include examples *.txt *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include *.rst
 include *.txt
 recursive-include examples *.txt *.py


### PR DESCRIPTION
Trying to install `DnaCauldron` from PyPI currently fails:
```console
$ pip install --user -U dnacauldron
Collecting dnacauldron
  Using cached https://files.pythonhosted.org/packages/cd/b1/85b1f3a9d42a63daa3efc20dc8b8a0f124d91320208824845d6329f9af6f/dnacauldron-0.1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-e_j8hp_r/dnacauldron/setup.py", line 13, in <module>
        long_description=open('pypi-readme.rst').read(),
    FileNotFoundError: [Errno 2] No such file or directory: 'pypi-readme.rst'
```

I edited the `MANIFEST.in` file so that `pypi-readme.rst` and `ez_setup.py` are added to the source distribution.