### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/dnacauldron/SequenceRepository.py
+++ b/dnacauldron/SequenceRepository.py
@@ -3,7 +3,7 @@ from .biotools import (
     set_record_topology,
     sequence_to_biopython_record,
 )
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 class NotInRepositoryError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "Biopython",
         "numpy",
         "matplotlib",
-        "fuzzywuzzy",
+        "rapidfuzz",
         "pandas",
         "scipy",
         "networkx",
@@ -31,7 +31,6 @@ setup(
         "proglog",
         "xlwt",
         "openpyxl",
-        "python-Levenshtein",
         "xlrd",
     ],
 )


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy