### PR TITLE
Fix #18 : account for new "inplace" parameter in more recent biopython

### DIFF
--- a/dnacauldron/Assembly/builtin_assembly_classes/BASICAssembly.py
+++ b/dnacauldron/Assembly/builtin_assembly_classes/BASICAssembly.py
@@ -52,7 +52,7 @@ class BASICAssembly(Assembly):
       assembly, or are depended on by it.
 
     """
-    def simulate_adapters_assembly(self, records):
+    def simulate_adapters_assembly(self, records, sequence_repository):
         original_part = records[1]
         mix = RestrictionLigationMix(
             records,
@@ -69,8 +69,9 @@ class BASICAssembly(Assembly):
             error = AssemblyFlaw(
                 message="Two many fragments have a long overhang",
                 data={"parts": [r.id for r in records]},
+                assembly=self
             )
-            return AssemblySimulation(errors=[error], mixes=(mix,))
+            return mix, error
         graph = mix.connections_graph
         constructs = []
         for start, end in itertools.product(adapter_fragments, repeat=2):
@@ -118,7 +119,7 @@ class BASICAssembly(Assembly):
         errors, warnings = [], []
         part_triplets = [parts[i : i + 3] for i in range(0, L, 3)]
         for triplet in part_triplets:
-            simulation = self.simulate_adapters_assembly(triplet)
+            simulation = self.simulate_adapters_assembly(triplet, sequence_repository)
             if isinstance(simulation, StickyEndFragment):
                 adapted_part_records.append(simulation)
             else:

--- a/dnacauldron/Fragment/StickyEndFragment/StickyEnd.py
+++ b/dnacauldron/Fragment/StickyEndFragment/StickyEnd.py
@@ -29,7 +29,7 @@ class StickyEnd(Seq):
       Optional keyword arguments for the sequence, such as ``alphabet`` etc.
     """
 
-    def __init__(self, data, strand, **k):
+    def __init__(self, data, strand=None, **k):
         Seq.__init__(self, str(data).upper(), **k)
         self.strand = strand
 
@@ -42,7 +42,7 @@ class StickyEnd(Seq):
                 alphabet=self.alphabet,
             )
         else:
-            return StickyEnd(str(Seq.reverse_complement(self)), strand=-self.strand,)
+            return StickyEnd(str(Seq(self).reverse_complement()), strand=-self.strand,)
 
     def __repr__(self):
         return "%s(%s)" % (Seq.__str__(self), {1: "+", -1: "-"}[self.strand])

--- a/dnacauldron/Fragment/StickyEndFragment/StickyEndSeq.py
+++ b/dnacauldron/Fragment/StickyEndFragment/StickyEndSeq.py
@@ -24,7 +24,7 @@ class StickyEndSeq(Seq):
         self.left_end = left_end
         self.right_end = right_end
 
-    def reverse_complement(self):
+    def reverse_complement(self, inplace=False):
         """The reverse is a StickyEndSeq with reversed ends
 
         left-right versions are interchanged and reverse complemented.
@@ -43,7 +43,7 @@ class StickyEndSeq(Seq):
             )
         else:
             sticky_end_seq = StickyEndSeq(
-                str(Seq.reverse_complement(self)),
+                str(Seq(self).reverse_complement()),
                 left_end=None
                 if self.right_end is None
                 else self.right_end.reverse_complement(),

--- a/tests/test_utils/test_utils.py
+++ b/tests/test_utils/test_utils.py
@@ -21,7 +21,7 @@ def test_insert_parts_on_backbones(tmpdir):
     assert resultA.backbone_record.id == "partA2"
     assert resultB.backbone_record.id == "partB2"
     dataframe = dc.BackboneChoice.list_to_infos_spreadsheet(choices)
-    dataframe.to_excel(os.path.join(str(tmpdir), "summary.xls"), index=False)
+    dataframe.to_excel(os.path.join(str(tmpdir), "summary.xlsx"), index=False)
     dc.BackboneChoice.write_final_records(choices, str(tmpdir))
 
 def test_swap_donor_vector_part():


### PR DESCRIPTION
Addresses #18

@veghp It looks like Travis stopped working? Tests are all passing on my machine (with recent versions of biopython, etc.) and I'm guessing they should still be passing on pre-1.78 versions given that these are handled in the code.