### PR TITLE
fix write_report() for zip files

### DIFF
--- a/dnacauldron/Assembly/AssemblyReportWriter/AssemblyReportWriter.py
+++ b/dnacauldron/Assembly/AssemblyReportWriter/AssemblyReportWriter.py
@@ -182,5 +182,5 @@ class AssemblyReportWriter(AssemblyReportPlotsMixin):
                 assembly_simulation, report_root, error_type="warnings"
             )
 
-        if target == "@memory":
+        if hasattr(report_root, "_close"):
             return report_root._close()

--- a/dnacauldron/Assembly/AssemblyReportWriter/AssemblyReportWriter.py
+++ b/dnacauldron/Assembly/AssemblyReportWriter/AssemblyReportWriter.py
@@ -182,5 +182,5 @@ class AssemblyReportWriter(AssemblyReportPlotsMixin):
                 assembly_simulation, report_root, error_type="warnings"
             )
 
-        if hasattr(report_root, "_close"):
+        if (target == "@memory") or str(target).endswith(".zip"):
             return report_root._close()


### PR DESCRIPTION
Heya! It's been brought to my attention that the README shows `simulation.write_report("report.zip")` as an example, but it actually doesn't work, it returns an empty zip file, becauser the zip handle is not `closed()` after writing. This MR fixes that.